### PR TITLE
net_accept(): Inherit PPID from listening socket

### DIFF
--- a/lib/core/src/unix/net_lib.c
+++ b/lib/core/src/unix/net_lib.c
@@ -638,6 +638,7 @@ int  net_accept(net_sock_t **new_accept_sock, net_sock_t *net_sock, int timeout)
 
             node->sock_id = new_sock;
             node->proto = net_sock->proto;
+            node->ppid = net_sock->ppid;
             *new_accept_sock = node;
 
             /* Save local and remote address */


### PR DESCRIPTION
When we call accept() on a listening socket, we need to inherit
the sctp PPID from the master socket to the new socket of the
just-accepted connection.  Otherwise any sent packets (such as S1AP)
will be sent to PPID=0 rather than the configured PPID (e.g. 18 for
S1AP).