### PR TITLE
Network Name

### DIFF
--- a/src/mme/emm_handler.c
+++ b/src/mme/emm_handler.c
@@ -195,7 +195,7 @@ status_t emm_handle_attach_complete(
         NAS_EMM_INFORMATION_UNIVERSAL_TIME_AND_LOCAL_TIME_ZONE_PRESENT;
     universal_time_and_local_time_zone->year = 
                 NAS_TIME_TO_BCD(time_exp.tm_year % 100);
-    universal_time_and_local_time_zone->mon = NAS_TIME_TO_BCD(time_exp.tm_mon);
+    universal_time_and_local_time_zone->mon = NAS_TIME_TO_BCD(time_exp.tm_mon+1);
     universal_time_and_local_time_zone->mday = 
                 NAS_TIME_TO_BCD(time_exp.tm_mday);
     universal_time_and_local_time_zone->hour = 

--- a/src/mme/emm_handler.c
+++ b/src/mme/emm_handler.c
@@ -214,13 +214,17 @@ status_t emm_handle_attach_complete(
         NAS_EMM_INFORMATION_NETWORK_DAYLIGHT_SAVING_TIME_PRESENT;
     network_daylight_saving_time->length = 1;
 
-
-    emm_information->presencemask |= NAS_EMM_INFORMATION_FULL_NAME_FOR_NETWORK_TYPE;
-    memcpy(&emm_information->full_name_for_network, &mme_self()->full_name, sizeof(nas_network_name_t));
-
-    emm_information->presencemask |= NAS_EMM_INFORMATION_SHORT_NAME_FOR_NETWORK_TYPE;
-    memcpy(&emm_information->short_name_for_network, &mme_self()->short_name, sizeof(nas_network_name_t));
-                    
+    if(mme_self()->full_name.length) 
+    {
+	emm_information->presencemask |= NAS_EMM_INFORMATION_FULL_NAME_FOR_NETWORK_TYPE;
+	memcpy(&emm_information->full_name_for_network, &mme_self()->full_name, sizeof(nas_network_name_t));
+    }
+    
+    if(mme_self()->short_name.length)
+    {
+	emm_information->presencemask |= NAS_EMM_INFORMATION_SHORT_NAME_FOR_NETWORK_TYPE;
+	memcpy(&emm_information->short_name_for_network, &mme_self()->short_name, sizeof(nas_network_name_t));
+    }                
 
     rv = nas_security_encode(&emmbuf, mme_ue, &message);
     d_assert(rv == CORE_OK && emmbuf, return CORE_ERROR, "emm build error");

--- a/src/mme/emm_handler.c
+++ b/src/mme/emm_handler.c
@@ -214,6 +214,14 @@ status_t emm_handle_attach_complete(
         NAS_EMM_INFORMATION_NETWORK_DAYLIGHT_SAVING_TIME_PRESENT;
     network_daylight_saving_time->length = 1;
 
+
+    emm_information->presencemask |= NAS_EMM_INFORMATION_FULL_NAME_FOR_NETWORK_TYPE;
+    memcpy(&emm_information->full_name_for_network, &mme_self()->full_name, sizeof(nas_network_name_t));
+
+    emm_information->presencemask |= NAS_EMM_INFORMATION_SHORT_NAME_FOR_NETWORK_TYPE;
+    memcpy(&emm_information->short_name_for_network, &mme_self()->short_name, sizeof(nas_network_name_t));
+                    
+
     rv = nas_security_encode(&emmbuf, mme_ue, &message);
     d_assert(rv == CORE_OK && emmbuf, return CORE_ERROR, "emm build error");
     d_assert(nas_send_to_downlink_nas_transport(mme_ue, emmbuf) == CORE_OK,,);

--- a/src/mme/mme_context.c
+++ b/src/mme/mme_context.c
@@ -1211,6 +1211,51 @@ status_t mme_context_parse_config()
                         }
                     }
                 }
+		else if(!strcmp(mme_key, "network_name"))
+                {
+                    yaml_iter_t network_name_iter;
+                    yaml_iter_recurse(&mme_iter, &network_name_iter);
+
+                    while(yaml_iter_next(&network_name_iter))
+                    {
+                        const char *network_name_key =
+                        yaml_iter_key(&network_name_iter);
+                        d_assert(network_name_key,
+                                    return CORE_ERROR,);
+                        if (!strcmp(network_name_key, "full"))
+                        {  
+                            nas_network_name_t *network_full_name = &self.full_name;
+                            const char *c_network_name = yaml_iter_value(&network_name_iter);
+                            c_uint8_t size = strlen(c_network_name);
+                            c_uint8_t i;
+                            for(i = 0;i<size;i++)
+                            {
+                                /* Workaround to convert the ASCII to USC-2 */
+                                network_full_name->name[i*2] = 0;
+                                network_full_name->name[(i*2)+1] = c_network_name[i];
+
+                            }
+                                network_full_name->length = size*2+1;
+                                network_full_name->coding_scheme = 1;
+                        }
+                        else if (!strcmp(network_name_key, "short"))
+                        {
+                            nas_network_name_t *network_short_name = &self.short_name;
+                            const char *c_network_name = yaml_iter_value(&network_name_iter);
+                            c_uint8_t size = strlen(c_network_name);
+                            c_uint8_t i;
+                            for(i = 0;i<size;i++)
+                            {
+                                /* Workaround to convert the ASCII to USC-2 */
+                                network_short_name->name[i*2] = 0;
+                                network_short_name->name[(i*2)+1] = c_network_name[i];
+
+                            }
+                            network_short_name->length = size*2+1;
+                            network_short_name->coding_scheme = 1;
+                        }
+                    }
+                }
                 else
                     d_warn("unknown key `%s`", mme_key);
             }

--- a/src/mme/mme_context.h
+++ b/src/mme/mme_context.h
@@ -132,6 +132,11 @@ typedef struct _mme_context_t {
     /* System */
     msgq_id         queue_id;       /* Queue for processing MME control plane */
     tm_service_t    tm_service;     /* Timer Service */
+    
+    /* Network Name */    
+    nas_network_name_t short_name; /* Network short name */
+    nas_network_name_t full_name; /* Network Full Name */
+                        
 } mme_context_t;
 
 typedef struct _mme_enb_t {

--- a/support/config/mme.conf.in
+++ b/support/config/mme.conf.in
@@ -29,6 +29,9 @@ mme:
     security:
         integrity_order : [ EIA1, EIA2, EIA0 ]
         ciphering_order : [ EEA0, EEA1, EEA2 ]
+    network_name:
+        full: NextEPC
+        short: NEPC
 
 sgw:
     gtpc:


### PR DESCRIPTION
Hello, 

Firstly congratulations for your project, it is very useful LTE EPC software.

I made a little change in these source files, that will provide a config option to change the Network name that will be show in the UE instead of the MNC + MCC code.

With this we need add these option in mme.conf file:

    network_name:
        full: NextEPC
        short: NEPC

In attached you can found a photo showing the Network name in the UE.

Thanks
![img_3078](https://user-images.githubusercontent.com/1965569/36646832-b5689056-1a5b-11e8-9036-129cefcd09e2.jpg)
![img_3077](https://user-images.githubusercontent.com/1965569/36646833-b58a4d22-1a5b-11e8-85f9-1e9025f81b00.jpg)



R.Medeiros
