### PR TITLE
Small fix to set correct timezone in UE.

### DIFF
--- a/src/mme/emm_handler.c
+++ b/src/mme/emm_handler.c
@@ -181,7 +181,7 @@ status_t emm_handle_attach_complete(
         &emm_information->network_daylight_saving_time;
 
     time_exp_t time_exp;
-    time_exp_lt(&time_exp, time_now());
+    time_exp_gmt(&time_exp, time_now());
 
     d_assert(mme_ue, return CORE_ERROR, "Null param");
 


### PR DESCRIPTION
Hello to again.

I made a small fix to set the correctly the clock in LTE Phones in when NextEPC run in a Linux.

Thanks in advance

Romeu Medeiros