### PR TITLE
Modify the plmn_id.

### DIFF
--- a/lib/core/include/3gpp_types.h
+++ b/lib/core/include/3gpp_types.h
@@ -65,10 +65,10 @@ extern "C" {
 typedef struct _plmn_id_t {
 ED2(c_uint8_t mcc2:4;,
     c_uint8_t mcc1:4;)
-ED2(c_uint8_t mnc1:4;,
-    c_uint8_t mcc3:4;)
 ED2(c_uint8_t mnc3:4;,
-    c_uint8_t mnc2:4;)
+    c_uint8_t mcc3:4;)
+ED2(c_uint8_t mnc2:4;,
+    c_uint8_t mnc1:4;)
 } __attribute__ ((packed)) plmn_id_t;
 
 CORE_DECLARE(c_uint16_t) plmn_id_mcc(plmn_id_t *plmn_id);

--- a/lib/core/src/3gpp_types.c
+++ b/lib/core/src/3gpp_types.c
@@ -16,12 +16,12 @@ c_uint16_t plmn_id_mcc(plmn_id_t *plmn_id)
 }
 c_uint16_t plmn_id_mnc(plmn_id_t *plmn_id)
 {
-    return plmn_id->mnc1 == 0xf ? plmn_id->mnc2 * 10 + plmn_id->mnc3 :
+    return plmn_id->mnc3 == 0xf ? plmn_id->mnc1 * 10 + plmn_id->mnc2 :
         plmn_id->mnc1 * 100 + plmn_id->mnc2 * 10 + plmn_id->mnc3;
 }
 c_uint16_t plmn_id_mnc_len(plmn_id_t *plmn_id)
 {
-    return plmn_id->mnc1 == 0xf ? 2 : 3;
+    return plmn_id->mnc3 == 0xf ? 2 : 3;
 }
 
 void *plmn_id_build(plmn_id_t *plmn_id, 
@@ -31,13 +31,14 @@ void *plmn_id_build(plmn_id_t *plmn_id,
     plmn_id->mcc2 = PLMN_ID_DIGIT2(mcc);
     plmn_id->mcc3 = PLMN_ID_DIGIT3(mcc);
 
-    if (mnc_len == 2)
-        plmn_id->mnc1 = 0xf;
-    else
-        plmn_id->mnc1 = PLMN_ID_DIGIT1(mnc);
+    if (mnc_len == 2) {
+        plmn_id->mnc3 = 0xf;
+        mnc *= 10;
+    } else
+        plmn_id->mnc3 = PLMN_ID_DIGIT3(mnc);
 
     plmn_id->mnc2 = PLMN_ID_DIGIT2(mnc);
-    plmn_id->mnc3 = PLMN_ID_DIGIT3(mnc);
+    plmn_id->mnc1 = PLMN_ID_DIGIT1(mnc);
 
     return plmn_id;
 }


### PR DESCRIPTION
When we build the plmn_id by 3 digits mnc, an incorrect plmn_id was built.
If we pass mcc=311, mnc=280, and the length of mnc=3 to the plmn_id_build(),
it build a plmn_id=(13 21 08).
But we expect the plmn_id_build() returns plmn_id=(13 01 82).
I referred the following links.
 http://lteuniversity.com/ask_the_expert/f/59/t/3387.aspx
 https://forum.sierrawireless.com/t/hilo-how-to-decode-plmn-in-the-result-of-kcell/6466
 
So, I modified the lib/core/include/3gpp_types.h and lib/core/src/3gpp_types.c.

I've checked to pass all the tests.

$ ./test/testepc
  PID[7177] : '/home/shiro/modify_plmn_id/nextepc/install/var/run/nextepc-epcd/pid'
  File Logging : '/home/shiro/modify_plmn_id/nextepc/install/var/log/nextepc/nextepc.log'
  MongoDB URI : 'mongodb://localhost/nextepc'
  Configuration : '/home/shiro/modify_plmn_id/nextepc/install/etc/nextepc/nextepc.conf'
s1ap_message_test   : SUCCESS
nas_message_test    : SUCCESS
gtp_message_test    : SUCCESS
security_test       : SUCCESS
s1setup_test        : SUCCESS
attach_test         : SUCCESS
volte_test          : SUCCESS
handover_test       : SUCCESS
All tests passed.

Could you please consider my request?
Thank you.